### PR TITLE
Extending context for receipt view.

### DIFF
--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -197,7 +197,8 @@ class ReceiptResponseView(ThankYouView):
         context.update(self.get_show_verification_banner_context(context))
         context.update({
             'explore_courses_url': get_lms_explore_courses_url(),
-            'has_enrollment_code_product': has_enrollment_code_product
+            'has_enrollment_code_product': has_enrollment_code_product,
+            'custom_settings': self.request.site.siteconfiguration.custom_settings,
         })
         return context
 


### PR DESCRIPTION
This PR adds the context available at the "custom_settings" object over the receipt view.

@Squirrel18 

